### PR TITLE
Add custom columns to security CRDs

### DIFF
--- a/deploy/audit-crd.yaml
+++ b/deploy/audit-crd.yaml
@@ -39,3 +39,20 @@ spec:
           properties:
             state:
               type: string
+  additionalPrinterColumns:
+  - name: ReleaseName
+    type: string
+    JSONPath: .spec.releaseName
+    priority: 1
+  - name: Image
+    type: string
+    JSONPath: .spec.image
+    priority: 2
+  - name: result
+    type: string
+    JSONPath: .spec.result
+    priority: 3
+  - name: action
+    type: string
+    JSONPath: .spec.action
+    priority: 4

--- a/deploy/whitelist-crd.yaml
+++ b/deploy/whitelist-crd.yaml
@@ -27,3 +27,16 @@ spec:
               type: string
             creator:
               type: string
+  additionalPrinterColumns:
+  - name: ReleaseName
+    type: string
+    JSONPath: .spec.releaseName
+    priority: 1
+  - name: Reason
+    type: string
+    JSONPath: .spec.readson
+    priority: 2
+  - name: Creator
+    type: string
+    JSONPath: .spec.creator
+    priority: 3


### PR DESCRIPTION
Add custom column definitions to security CRDs. Works if K8s version > 1.11
