### PR TITLE
Remove releaseName from whitelistitem spec

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.docker/
+bin/
+vendor/

--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -40,7 +40,7 @@ func checkWhiteList(wl []v1alpha1.WhiteListItem, r string, f bool) bool {
 			"FakeRelease": true,
 		}).Info("Missing release label, using PodName")
 		for _, res := range wl {
-			fakeRelease := string(res.Spec.ReleaseName + "-")
+			fakeRelease := string(res.ObjectMeta.Name + "-")
 			if strings.Contains(r, fakeRelease) {
 				return true
 			}
@@ -50,7 +50,7 @@ func checkWhiteList(wl []v1alpha1.WhiteListItem, r string, f bool) bool {
 			"release": r,
 		}).Info("Check whitelist")
 		for _, res := range wl {
-			if r == res.Spec.ReleaseName {
+			if r == res.ObjectMeta.Name {
 				return true
 			}
 		}

--- a/deploy/whitelist-crd.yaml
+++ b/deploy/whitelist-crd.yaml
@@ -17,26 +17,19 @@ spec:
       properties:
         spec:
           required:
-            - releaseName
             - reason
             - creator
           properties:
-            relaseName:
-              type: string
             reason:
               type: string
             creator:
               type: string
   additionalPrinterColumns:
-  - name: ReleaseName
-    type: string
-    JSONPath: .spec.releaseName
-    priority: 1
   - name: Reason
     type: string
     JSONPath: .spec.readson
-    priority: 2
+    priority: 1
   - name: Creator
     type: string
     JSONPath: .spec.creator
-    priority: 3
+    priority: 2

--- a/pkg/apis/security/v1alpha1/deepcopy.go
+++ b/pkg/apis/security/v1alpha1/deepcopy.go
@@ -7,9 +7,8 @@ func (in *WhiteListItem) DeepCopyInto(out *WhiteListItem) {
 	out.TypeMeta = in.TypeMeta
 	out.ObjectMeta = in.ObjectMeta
 	out.Spec = WhiteListSpec{
-		ReleaseName: in.Spec.ReleaseName,
-		Creator:     in.Spec.Creator,
-		Reason:      in.Spec.Reason,
+		Creator: in.Spec.Creator,
+		Reason:  in.Spec.Reason,
 	}
 }
 

--- a/pkg/apis/security/v1alpha1/types.go
+++ b/pkg/apis/security/v1alpha1/types.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// WhiteList for whitelisting crd
+// WhiteListItemList for whitelisting crd
 type WhiteListItemList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -20,9 +20,8 @@ type WhiteListItem struct {
 
 // WhiteListSpec for WhiteListItem
 type WhiteListSpec struct {
-	ReleaseName string `json:"releaseName"`
-	Creator     string `json:"creator"`
-	Reason      string `json:"reason"`
+	Creator string `json:"creator"`
+	Reason  string `json:"reason"`
 }
 
 // AuditList for Scan events


### PR DESCRIPTION
ReleaseName isn't necessary to declare in WhitelistItem Spec, it's removed.