### PR TITLE
Remove namespace in case of custom resources

### DIFF
--- a/cmd/handler.go
+++ b/cmd/handler.go
@@ -120,10 +120,10 @@ func createOrUpdateAudit(a auditInfo) {
 	tail := []byte(`}`)
 	actionByte = append(actionByte, tail...)
 	auditCR.SetOwnerReferences(a.owners)
-	audit, err := securityClientSet.Audits("default").Create(auditCR)
+	audit, err := securityClientSet.Audits().Create(auditCR)
 	if err != nil {
 		logrus.Error(err)
-		audit, err = securityClientSet.Audits("default").Update(a.name, actionByte)
+		audit, err = securityClientSet.Audits().Update(a.name, actionByte)
 		if err != nil {
 			logrus.Error(err)
 		} else {
@@ -139,7 +139,7 @@ func createOrUpdateAudit(a auditInfo) {
 }
 
 func listAudits() {
-	audits, err := securityClientSet.Audits("default").List(metav1.ListOptions{})
+	audits, err := securityClientSet.Audits().List(metav1.ListOptions{})
 	if err != nil {
 		logrus.Error(err)
 	} else {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 	"github.com/sirupsen/logrus"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -88,7 +88,7 @@ func (a *admissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionReques
 		Result:  &metav1.Status{Status: "Success", Message: ""}}
 
 	if admissionSpec.Kind.Kind == "Pod" {
-		whitelists, err := securityClientSet.Whitelists("default").List(metav1.ListOptions{})
+		whitelists, err := securityClientSet.Whitelists().List(metav1.ListOptions{})
 		if err != nil {
 			logrus.Error(err)
 		} else {

--- a/pkg/clientset/v1alpha1/api.go
+++ b/pkg/clientset/v1alpha1/api.go
@@ -51,17 +51,15 @@ func SecurityConfig(c *rest.Config) (*SecurityV1Alpha1Client, error) {
 }
 
 // Audits returns Audits for client
-func (c *SecurityV1Alpha1Client) Audits(namespace string) AuditInterface {
+func (c *SecurityV1Alpha1Client) Audits() AuditInterface {
 	return &auditClient{
 		restClient: c.restClient,
-		ns:         namespace,
 	}
 }
 
 // Whitelists return WhiteLists for client
-func (c *SecurityV1Alpha1Client) Whitelists(namespace string) WhiteListInterface {
+func (c *SecurityV1Alpha1Client) Whitelists() WhiteListInterface {
 	return &whitelistClient{
 		restClient: c.restClient,
-		ns:         namespace,
 	}
 }

--- a/pkg/clientset/v1alpha1/audit.go
+++ b/pkg/clientset/v1alpha1/audit.go
@@ -40,7 +40,6 @@ func (c *auditClient) List(opts metav1.ListOptions) (*v1alpha1.AuditList, error)
 	result := v1alpha1.AuditList{}
 	err := c.restClient.
 		Get().
-		Namespace(c.ns).
 		Resource("audits").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -53,7 +52,6 @@ func (c *auditClient) Get(name string, opts metav1.GetOptions) (*v1alpha1.Audit,
 	result := v1alpha1.Audit{}
 	err := c.restClient.
 		Get().
-		Namespace(c.ns).
 		Resource("audits").
 		Name(name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -67,7 +65,6 @@ func (c *auditClient) Create(audit *v1alpha1.Audit) (*v1alpha1.Audit, error) {
 	result := v1alpha1.Audit{}
 	err := c.restClient.
 		Post().
-		Namespace(c.ns).
 		Resource("audits").
 		Body(audit).
 		Do().
@@ -80,7 +77,6 @@ func (c *auditClient) Update(name string, auditPatch []byte) (*v1alpha1.Audit, e
 	result := v1alpha1.Audit{}
 	err := c.restClient.
 		Patch(types.MergePatchType).
-		Namespace(c.ns).
 		Resource("audits").
 		Name(name).
 		Body(auditPatch).

--- a/pkg/clientset/v1alpha1/audit.go
+++ b/pkg/clientset/v1alpha1/audit.go
@@ -33,7 +33,6 @@ type AuditInterface interface {
 
 type auditClient struct {
 	restClient rest.Interface
-	ns         string
 }
 
 func (c *auditClient) List(opts metav1.ListOptions) (*v1alpha1.AuditList, error) {

--- a/pkg/clientset/v1alpha1/whitelist.go
+++ b/pkg/clientset/v1alpha1/whitelist.go
@@ -39,7 +39,6 @@ func (c *whitelistClient) List(opts metav1.ListOptions) (*v1alpha1.WhiteListItem
 	result := v1alpha1.WhiteListItemList{}
 	err := c.restClient.
 		Get().
-		Namespace(c.ns).
 		Resource("whitelistitems").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Do().
@@ -52,7 +51,6 @@ func (c *whitelistClient) Get(name string, opts metav1.GetOptions) (*v1alpha1.Wh
 	result := v1alpha1.WhiteListItem{}
 	err := c.restClient.
 		Get().
-		Namespace(c.ns).
 		Resource("whitelistitems").
 		Name(name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -66,7 +64,6 @@ func (c *whitelistClient) Create(whiteListItem *v1alpha1.WhiteListItem) (*v1alph
 	result := v1alpha1.WhiteListItem{}
 	err := c.restClient.
 		Post().
-		Namespace(c.ns).
 		Resource("whitelistitems").
 		Body(whiteListItem).
 		Do().
@@ -79,7 +76,6 @@ func (c *whitelistClient) Delete(name string, options *metav1.DeleteOptions) err
 
 	return c.restClient.
 		Delete().
-		Namespace(c.ns).
 		Resource("whitelistitems").
 		Name(name).
 		Body(options).

--- a/pkg/clientset/v1alpha1/whitelist.go
+++ b/pkg/clientset/v1alpha1/whitelist.go
@@ -32,7 +32,6 @@ type WhiteListInterface interface {
 
 type whitelistClient struct {
 	restClient rest.Interface
-	ns         string
 }
 
 func (c *whitelistClient) List(opts metav1.ListOptions) (*v1alpha1.WhiteListItemList, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | yes
| Deprecations?   | no
| Related PR | https://github.com/banzaicloud/banzai-charts/pull/925
| License         | Apache 2.0


### What's in this PR?
In case of cluster scoped custom resources don't specify namespace.

- [x] Related Helm chart(s) updated (if needed)
