### PR TITLE
fix: dont set ownerreference in the case of audit custom resource

### DIFF
--- a/charts/anchore-policy-validator/Chart.yaml
+++ b/charts/anchore-policy-validator/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.7.3
-appVersion: 0.5.3
+version: 0.7.4
+appVersion: 0.5.4
 keywords:
- - analysis
- - "anchore-policy-validator"
- - image
- - security
+  - analysis
+  - "anchore-policy-validator"
+  - image
+  - security
 home: https://github.com/banzaicloud/anchore-image-validator
 maintainers:
-- name: BanzaiCloud
-  email: info@banzaicloud.com
+  - name: BanzaiCloud
+    email: info@banzaicloud.com
 engine: gotpl

--- a/internal/app/handler.go
+++ b/internal/app/handler.go
@@ -126,7 +126,7 @@ func createOrUpdateAudit(a auditInfo, c client.Client) {
 		},
 	}
 
-	auditCR.SetOwnerReferences(a.owners)
+	// auditCR.SetOwnerReferences(a.owners)
 
 	if err := c.Create(context.Background(), auditCR); err != nil {
 		logrus.Error(err)


### PR DESCRIPTION
Signed-off-by: Peter Balogh <p.balogh.sa@gmail.com>

| Q               | A
| --------------- | ---
| Bug fix?        |yes (in the case of 1.20)
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Ownerreference of audit cr in the case of K8s 1.20 cause some issues due to audit CRs are cluster scoped and their owners are namespaced (the owner of an audit CR is the scanned deployment).