### PR TITLE
Support for kubernetes version 1.22

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -4,10 +4,9 @@ on:
     branches:
       - master
     paths:
-      - 'charts/**'
+      - "charts/**"
 
 jobs:
-
   lint-test:
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +25,7 @@ jobs:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 

--- a/charts/anchore-policy-validator/Chart.yaml
+++ b/charts/anchore-policy-validator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.7.4
+version: 0.7.5
 appVersion: 0.5.4
 keywords:
   - analysis

--- a/charts/anchore-policy-validator/Chart.yaml
+++ b/charts/anchore-policy-validator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for anchore-policy-validator admission controller
 name: anchore-policy-validator
-version: 0.7.5
+version: 0.8.1
 appVersion: 0.5.4
 keywords:
   - analysis

--- a/charts/anchore-policy-validator/README.md
+++ b/charts/anchore-policy-validator/README.md
@@ -4,6 +4,8 @@ This chart deploys an admission-server that is used as a ValidatingWebhook in a 
 
 ## Installing the Chart
 
+>Supported Kubernetes versions: >= 1.16.
+
 ```bash
 $ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com/
 $ helm repo update

--- a/charts/anchore-policy-validator/templates/audit-crd.yaml
+++ b/charts/anchore-policy-validator/templates/audit-crd.yaml
@@ -1,67 +1,74 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: audits.security.banzaicloud.com
 spec:
   group: security.banzaicloud.com
-  version: v1alpha1
   names:
     kind: Audit
     plural: audits
     singular: audit
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-            - releaseName
-            - resource
-            - image
-            - result
-            - action
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            releaseName:
-              type: string
-            resource:
-              type: string
-            image:
-              type: array
-              items:
-                type: object
-                properties:
-                  imageName:
+            spec:
+              required:
+                - releaseName
+                - resource
+                - image
+                - result
+                - action
+              properties:
+                releaseName:
+                  type: string
+                resource:
+                  type: string
+                image:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      imageName:
+                        type: string
+                      imageTag:
+                        type: string
+                      imageDigest:
+                        type: string
+                      lastUpdated:
+                        type: string
+                result:
+                  type: array
+                  items:
                     type: string
-                  imageTag:
-                    type: string
-                  imageDigest:
-                    type: string
-                  lastUpdated:
-                    type: string
-            result:
-              type: array
-              items:
-                type: string
-            action:
-              type: string
-        status:
-          properties:
-            state:
-              type: string
-  additionalPrinterColumns:
-  - name: ReleaseName
-    type: string
-    JSONPath: .spec.releaseName
-    priority: 1
-  - name: Image
-    type: string
-    JSONPath: .spec.image[*].imageName
-    priority: 2
-  - name: result
-    type: string
-    JSONPath: .spec.result
-    priority: 3
-  - name: action
-    type: string
-    JSONPath: .spec.action
-    priority: 4
+                action:
+                  type: string
+              type: object
+            status:
+              properties:
+                state:
+                  type: string
+              type: object
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        -   name: ReleaseName
+            type: string
+            jsonPath: .spec.releaseName
+            priority: 1
+        -   name: Image
+            type: string
+            jsonPath: .spec.image[*].imageName
+            priority: 2
+        -   name: result
+            type: string
+            jsonPath: .spec.result
+            priority: 3
+        -   name: action
+            type: string
+            jsonPath: .spec.action
+            priority: 4
+

--- a/charts/anchore-policy-validator/templates/whitelist-crd.yaml
+++ b/charts/anchore-policy-validator/templates/whitelist-crd.yaml
@@ -1,35 +1,40 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: whitelistitems.security.banzaicloud.com
 spec:
   group: security.banzaicloud.com
-  version: v1alpha1
   names:
     kind: WhiteListItem
     plural: whitelistitems
     singular: whitelistitem
   scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-            - reason
-            - creator
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            reason:
-              type: string
-            creator:
-              type: string
-            regexp:
-              type: string
-  additionalPrinterColumns:
-  - name: Reason
-    type: string
-    JSONPath: .spec.reason
-    priority: 1
-  - name: Creator
-    type: string
-    JSONPath: .spec.creator
-    priority: 2
+            spec:
+              required:
+                - reason
+                - creator
+              properties:
+                reason:
+                  type: string
+                creator:
+                  type: string
+                regexp:
+                  type: string
+              type: object
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Reason
+          type: string
+          jsonPath: .spec.reason
+          priority: 1
+        - name: Creator
+          type: string
+          jsonPath: .spec.creator
+          priority: 2

--- a/charts/anchore-policy-validator/templates/whitelist-crd.yaml
+++ b/charts/anchore-policy-validator/templates/whitelist-crd.yaml
@@ -8,6 +8,8 @@ spec:
     kind: WhiteListItem
     plural: whitelistitems
     singular: whitelistitem
+    shortNames:
+      - wl
   scope: Cluster
   versions:
     - name: v1alpha1

--- a/deploy/audit-crd.yaml
+++ b/deploy/audit-crd.yaml
@@ -1,67 +1,74 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: audits.security.banzaicloud.com
+    name: audits.security.banzaicloud.com
 spec:
-  group: security.banzaicloud.com
-  version: v1alpha1
-  names:
-    kind: Audit
-    plural: audits
-    singular: audit
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-            - releaseName
-            - resource
-            - image
-            - result
-            - action
-          properties:
-            releaseName:
-              type: string
-            resource:
-              type: string
-            image:
-              type: array
-              items:
-                type: object
-                properties:
-                  imageName:
-                    type: string
-                  imageTag:
-                    type: string
-                  imageDigest:
-                    type: string
-                  lastUpdated:
-                    type: string
-            result:
-              type: array
-              items:
-                type: string
-            action:
-              type: string
-        status:
-          properties:
-            state:
-              type: string
-  additionalPrinterColumns:
-  - name: ReleaseName
-    type: string
-    JSONPath: .spec.releaseName
-    priority: 1
-  - name: Image
-    type: string
-    JSONPath: .spec.image[*].imageName
-    priority: 2
-  - name: result
-    type: string
-    JSONPath: .spec.result
-    priority: 3
-  - name: action
-    type: string
-    JSONPath: .spec.action
-    priority: 4
+    group: security.banzaicloud.com
+    names:
+        kind: Audit
+        plural: audits
+        singular: audit
+    scope: Cluster
+    versions:
+        - name: v1alpha1
+          schema:
+              openAPIV3Schema:
+                  type: object
+                  properties:
+                      spec:
+                          required:
+                              - releaseName
+                              - resource
+                              - image
+                              - result
+                              - action
+                          properties:
+                              releaseName:
+                                  type: string
+                              resource:
+                                  type: string
+                              image:
+                                  type: array
+                                  items:
+                                      type: object
+                                      properties:
+                                          imageName:
+                                              type: string
+                                          imageTag:
+                                              type: string
+                                          imageDigest:
+                                              type: string
+                                          lastUpdated:
+                                              type: string
+                              result:
+                                  type: array
+                                  items:
+                                      type: string
+                              action:
+                                  type: string
+                          type: object
+                      status:
+                          properties:
+                              state:
+                                  type: string
+                          type: object
+          served: true
+          storage: true
+          additionalPrinterColumns:
+              -   name: ReleaseName
+                  type: string
+                  jsonPath: .spec.releaseName
+                  priority: 1
+              -   name: Image
+                  type: string
+                  jsonPath: .spec.image[*].imageName
+                  priority: 2
+              -   name: result
+                  type: string
+                  jsonPath: .spec.result
+                  priority: 3
+              -   name: action
+                  type: string
+                  jsonPath: .spec.action
+                  priority: 4
+

--- a/deploy/audit-crd.yaml
+++ b/deploy/audit-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: audits.security.banzaicloud.com

--- a/deploy/whitelist-crd.yaml
+++ b/deploy/whitelist-crd.yaml
@@ -1,37 +1,40 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: whitelistitems.security.banzaicloud.com
+    name: whitelistitems.security.banzaicloud.com
 spec:
-  group: security.banzaicloud.com
-  version: v1alpha1
-  names:
-    kind: WhiteListItem
-    plural: whitelistitems
-    singular: whitelistitem
-    shortnames:
-      - wl
-  scope: Cluster
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          required:
-            - reason
-            - creator
-          properties:
-            reason:
-              type: string
-            creator:
-              type: string
-            regexp:
-              type: string
-  additionalPrinterColumns:
-  - name: Reason
-    type: string
-    JSONPath: .spec.reason
-    priority: 1
-  - name: Creator
-    type: string
-    JSONPath: .spec.creator
-    priority: 2
+    group: security.banzaicloud.com
+    names:
+        kind: WhiteListItem
+        plural: whitelistitems
+        singular: whitelistitem
+    scope: Cluster
+    versions:
+        - name: v1alpha1
+          schema:
+              openAPIV3Schema:
+                  type: object
+                  properties:
+                      spec:
+                          required:
+                              - reason
+                              - creator
+                          properties:
+                              reason:
+                                  type: string
+                              creator:
+                                  type: string
+                              regexp:
+                                  type: string
+                          type: object
+          served: true
+          storage: true
+          additionalPrinterColumns:
+              - name: Reason
+                type: string
+                jsonPath: .spec.reason
+                priority: 1
+              - name: Creator
+                type: string
+                jsonPath: .spec.creator
+                priority: 2

--- a/deploy/whitelist-crd.yaml
+++ b/deploy/whitelist-crd.yaml
@@ -8,6 +8,8 @@ spec:
         kind: WhiteListItem
         plural: whitelistitems
         singular: whitelistitem
+        shortNames:
+          - wl
     scope: Cluster
     versions:
         - name: v1alpha1

--- a/deploy/whitelist-crd.yaml
+++ b/deploy/whitelist-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: whitelistitems.security.banzaicloud.com


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #96 
| License         | Apache 2.0

### What's in this PR?
Replace admissionregistration.k8s.io/v1beta1 not available from version 1.22 with admissionregistration.k8s.io/v1 available from version 1.16.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
